### PR TITLE
(fix) Share -> Sync.

### DIFF
--- a/src/mixin.rs
+++ b/src/mixin.rs
@@ -5,11 +5,11 @@ use shared::{ShareableMiddleware, Shared};
 /// for convenient additions of `ShareableMiddleware` as `Middleware`.
 pub trait SharedLink {
     /// Attach a `ShareableMiddleware` as a `Middleware`.
-    fn link_shared<S: ShareableMiddleware + Send + Share>(&mut self, S);
+    fn link_shared<S: ShareableMiddleware + Send + Sync>(&mut self, S);
 }
 
 impl<C: Chain> SharedLink for C {
-    fn link_shared<S: ShareableMiddleware + Send + Share>(&mut self, s: S) {
+    fn link_shared<S: ShareableMiddleware + Send + Sync>(&mut self, s: S) {
         self.link(Shared::new(s))
     }
 }

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -15,7 +15,7 @@ pub struct Persistent<Data, Phantom> {
     pub data: Arc<RWLock<Data>>
 }
 
-impl<D: Send + Share, P> Clone for Persistent<D, P> {
+impl<D: Send + Sync, P> Clone for Persistent<D, P> {
     fn clone(&self) -> Persistent<D, P> {
         Persistent {
             data: self.data.clone()
@@ -23,14 +23,14 @@ impl<D: Send + Share, P> Clone for Persistent<D, P> {
     }
 }
 
-impl<D: Send + Share, P> Middleware for Persistent<D, P> {
+impl<D: Send + Sync, P> Middleware for Persistent<D, P> {
     fn enter(&mut self, req: &mut Request, _: &mut Response) -> Status {
         req.alloy.insert::<Persistent<D, P>>(self.clone());
         Continue
     }
 }
 
-impl<D: Send + Share, P> Persistent<D, P> {
+impl<D: Send + Sync, P> Persistent<D, P> {
     /// Creates a new instance of `Persistent` containing the passed-in data.
     pub fn new(data: D) -> Persistent<D, P> {
         Persistent { data: Arc::new(RWLock::new(data)) }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -20,15 +20,15 @@ pub trait ShareableMiddleware {
 /// can be linked onto a `Chain` while still avoiding unnecessary copies.
 pub struct Shared {
     /// The wrapped `ShareableMiddleware`
-    pub middleware: Arc<Box<ShareableMiddleware + Send + Share>>
+    pub middleware: Arc<Box<ShareableMiddleware + Send + Sync>>
 }
 
 impl Shared {
     /// Creates a new instance of `Shared` containing the provided
     /// `ShareableMiddleware` and allowing it to be used as `Middleware`.
-    pub fn new<S: ShareableMiddleware + Send + Share>(s: S) -> Shared {
+    pub fn new<S: ShareableMiddleware + Send + Sync>(s: S) -> Shared {
         Shared {
-            middleware: Arc::new(box s as Box<ShareableMiddleware + Send + Share>)
+            middleware: Arc::new(box s as Box<ShareableMiddleware + Send + Sync>)
         }
     }
 }


### PR DESCRIPTION
Tracking yesterday's breaking change in **rust**, `Share` is now `Sync`.
