### PR TITLE
Update for req.alloy -> extensions rename

### DIFF
--- a/examples/hitcounter.rs
+++ b/examples/hitcounter.rs
@@ -13,14 +13,14 @@ use iron::{Request, Response, Iron, Server, Chain, Status, Continue, FromFn};
 pub struct HitCounter;
 
 fn hit_counter(req: &mut Request, _: &mut Response) -> Status {
-    let mut count = req.alloy.find::<Persistent<uint, HitCounter>>().unwrap().data.write();
+    let mut count = req.extensions.find::<Persistent<uint, HitCounter>>().unwrap().data.write();
     *count += 1;
     println!("{} hits!", *count);
     Continue
 }
 
 fn serve_hits(req: &mut Request, res: &mut Response) -> Status {
-    let mut count = req.alloy.find::<Persistent<uint, HitCounter>>().unwrap().data.read();
+    let mut count = req.extensions.find::<Persistent<uint, HitCounter>>().unwrap().data.read();
     let _ = res.serve(status::Ok, format!("{} hits!", *count));
     Continue
 }
@@ -33,4 +33,3 @@ fn main() {
     server.chain.link(FromFn::new(serve_hits));
     server.listen(Ipv4Addr(127, 0, 0, 1), 3001);
 }
-

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -25,7 +25,7 @@ impl<D: Send + Sync, P> Clone for Persistent<D, P> {
 
 impl<D: Send + Sync, P> Middleware for Persistent<D, P> {
     fn enter(&mut self, req: &mut Request, _: &mut Response) -> Status {
-        req.alloy.insert::<Persistent<D, P>>(self.clone());
+        req.extensions.insert::<Persistent<D, P>>(self.clone());
         Continue
     }
 }
@@ -36,4 +36,3 @@ impl<D: Send + Sync, P> Persistent<D, P> {
         Persistent { data: Arc::new(RWLock::new(data)) }
     }
 }
-


### PR DESCRIPTION
I didn't touch `src/test.rs` because I don't know how to run those, but it looks like they were out of date even before the alloy -> extensions rename (because the handler fns take an `Alloy` as a third arg).
