### PR TITLE
Build cleanly against iron 0.1.7 and rust nightly

### DIFF
--- a/examples/hitcounter.rs
+++ b/examples/hitcounter.rs
@@ -5,7 +5,7 @@ use iron::prelude::*;
 
 use persistent::Write;
 use iron::typemap::Key;
-use iron::{ChainBuilder, status};
+use iron::status;
 
 #[derive(Copy)]
 pub struct HitCounter;
@@ -21,8 +21,7 @@ fn serve_hits(req: &mut Request) -> IronResult<Response> {
 }
 
 fn main() {
-    let mut chain = ChainBuilder::new(serve_hits);
+    let mut chain = Chain::new(serve_hits);
     chain.link(Write::<HitCounter>::both(0));
     Iron::new(chain).listen("localhost:3000").unwrap();
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, deny(warnings))]
-#![allow(unstable)]
 #![deny(missing_docs)]
+#![feature(core)]
 
 //! A set of middleware for sharing data between requests in the Iron
 //! framework.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,23 +139,23 @@ impl<P: Key> BeforeMiddleware for Write<P> where P::Value: Send {
 }
 
 impl<P: Key> AfterMiddleware for State<P> where P::Value: Send + Sync {
-    fn after(&self, _: &mut Request, res: &mut Response) -> IronResult<()> {
+    fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
         res.extensions.insert::<State<P>>(self.data.clone());
-        Ok(())
+        Ok(res)
     }
 }
 
 impl<P: Key> AfterMiddleware for Read<P> where P::Value: Send + Sync {
-    fn after(&self, _: &mut Request, res: &mut Response) -> IronResult<()> {
+    fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
         res.extensions.insert::<Read<P>>(self.data.clone());
-        Ok(())
+        Ok(res)
     }
 }
 
 impl<P: Key> AfterMiddleware for Write<P> where P::Value: Send {
-    fn after(&self, _: &mut Request, res: &mut Response) -> IronResult<()> {
+    fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
         res.extensions.insert::<Write<P>>(self.data.clone());
-        Ok(())
+        Ok(res)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,20 +99,20 @@ impl<P: Key> Key for Write<P> where P::Value: 'static {
     type Value = Arc<Mutex<P::Value>>;
 }
 
-impl<P: Key> Plugin<Request> for State<P> where P::Value: Send + Sync {
-    fn eval(req: &mut Request, _: Phantom<State<P>>) -> Option<Arc<RwLock<P::Value>>> {
+impl<'a, P: Key> Plugin<Request<'a>> for State<P> where P::Value: Send + Sync {
+    fn eval(req: &mut Request<'a>, _: Phantom<State<P>>) -> Option<Arc<RwLock<P::Value>>> {
         req.extensions.get::<State<P>>().cloned()
     }
 }
 
-impl<P: Key> Plugin<Request> for Read<P> where P::Value: Send + Sync {
-    fn eval(req: &mut Request, _: Phantom<Read<P>>) -> Option<Arc<P::Value>> {
+impl<'a, P: Key> Plugin<Request<'a>> for Read<P> where P::Value: Send + Sync {
+    fn eval(req: &mut Request<'a>, _: Phantom<Read<P>>) -> Option<Arc<P::Value>> {
         req.extensions.get::<Read<P>>().cloned()
     }
 }
 
-impl<P: Key> Plugin<Request> for Write<P> where P::Value: Send {
-    fn eval(req: &mut Request, _: Phantom<Write<P>>) -> Option<Arc<Mutex<P::Value>>> {
+impl<'a, P: Key> Plugin<Request<'a>> for Write<P> where P::Value: Send {
+    fn eval(req: &mut Request<'a>, _: Phantom<Write<P>>) -> Option<Arc<Mutex<P::Value>>> {
         req.extensions.get::<Write<P>>().cloned()
     }
 }


### PR DESCRIPTION
Some trivial fixes to build cleanly against the latest Iron release and Rust nightly.

```
smash@winter ~/code/persistent (fix-build=) $ rustc --version
rustc 1.0.0-nightly (74b874071 2015-02-08 00:24:03 +0000)
smash@winter ~/code/persistent (fix-build=) $ cargo test
   Compiling phantom v0.0.3
   Compiling libc v0.1.2
   Compiling matches v0.1.2
   Compiling pkg-config v0.1.7
   Compiling rustc-serialize v0.2.12
   Compiling log v0.2.2
   Compiling gcc v0.1.7
   Compiling unsafe-any v0.2.2
   Compiling typeable v0.0.8
   Compiling modifier v0.0.9
   Compiling unicase v0.0.4
   Compiling typemap v0.0.8
   Compiling error v0.1.3
   Compiling mime v0.0.8
   Compiling plugin v0.2.0
   Compiling openssl-sys v0.3.1
   Compiling time v0.1.16
   Compiling openssl v0.3.1
   Compiling url v0.2.20
   Compiling cookie v0.1.11
   Compiling hyper v0.1.11
   Compiling iron v0.1.7
   Compiling persistent v0.0.2 (file:///home/smash/code/persistent)
     Running target/persistent-d90eb30edcbecd25

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

   Doc-tests persistent

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```