### PR TITLE
(feat) Use the new return type + rustup

### DIFF
--- a/examples/hitcounter.rs
+++ b/examples/hitcounter.rs
@@ -5,7 +5,7 @@ use iron::prelude::*;
 
 use persistent::Write;
 use iron::typemap::Key;
-use iron::{ChainBuilder, status};
+use iron::{status};
 
 #[derive(Copy)]
 pub struct HitCounter;
@@ -13,7 +13,7 @@ pub struct HitCounter;
 impl Key for HitCounter { type Value = usize; }
 
 fn serve_hits(req: &mut Request) -> IronResult<Response> {
-    let mutex = req.get::<Write<HitCounter>>().unwrap();
+    let mutex = req.get::<Write<HitCounter>>().ok().unwrap();
     let mut count = mutex.lock().unwrap();
 
     *count += 1;
@@ -21,7 +21,7 @@ fn serve_hits(req: &mut Request) -> IronResult<Response> {
 }
 
 fn main() {
-    let mut chain = ChainBuilder::new(serve_hits);
+    let mut chain = Chain::new(serve_hits);
     chain.link(Write::<HitCounter>::both(0));
     Iron::new(chain).listen("localhost:3000").unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, deny(warnings))]
-#![allow(unstable)]
 #![deny(missing_docs)]
+#![feature(core)]
 
 //! A set of middleware for sharing data between requests in the Iron
 //! framework.
@@ -11,7 +11,14 @@ extern crate plugin;
 use iron::{Request, Response, BeforeMiddleware, AfterMiddleware, IronResult};
 use iron::typemap::Key;
 use std::sync::{Arc, RwLock, Mutex};
-use plugin::{Plugin, Phantom};
+use plugin::Plugin;
+
+/// The type that can be returned by `eval` to indicate error.
+#[derive(Clone)]
+pub enum PersistentError {
+    /// The value was not found.
+    NotFound
+}
 
 /// Middleware for data that persists between requests with read and write capabilities.
 ///
@@ -99,21 +106,24 @@ impl<P: Key> Key for Write<P> where P::Value: 'static {
     type Value = Arc<Mutex<P::Value>>;
 }
 
-impl<P: Key> Plugin<Request> for State<P> where P::Value: Send + Sync {
-    fn eval(req: &mut Request, _: Phantom<State<P>>) -> Option<Arc<RwLock<P::Value>>> {
-        req.extensions.get::<State<P>>().cloned()
+impl<'a, P: Key> Plugin<Request<'a>> for State<P> where P::Value: Send + Sync {
+    type Error = PersistentError;
+    fn eval(req: &mut Request<'a>) -> Result<Arc<RwLock<P::Value>>, PersistentError> {
+        req.extensions.get::<State<P>>().cloned().ok_or(PersistentError::NotFound)
     }
 }
 
-impl<P: Key> Plugin<Request> for Read<P> where P::Value: Send + Sync {
-    fn eval(req: &mut Request, _: Phantom<Read<P>>) -> Option<Arc<P::Value>> {
-        req.extensions.get::<Read<P>>().cloned()
+impl<'a, P: Key> Plugin<Request<'a>> for Read<P> where P::Value: Send + Sync {
+    type Error = PersistentError;
+    fn eval(req: &mut Request<'a>) -> Result<Arc<P::Value>, PersistentError> {
+        req.extensions.get::<Read<P>>().cloned().ok_or(PersistentError::NotFound)
     }
 }
 
-impl<P: Key> Plugin<Request> for Write<P> where P::Value: Send {
-    fn eval(req: &mut Request, _: Phantom<Write<P>>) -> Option<Arc<Mutex<P::Value>>> {
-        req.extensions.get::<Write<P>>().cloned()
+impl<'a, P: Key> Plugin<Request<'a>> for Write<P> where P::Value: Send {
+    type Error = PersistentError;
+    fn eval(req: &mut Request<'a>) -> Result<Arc<Mutex<P::Value>>, PersistentError> {
+        req.extensions.get::<Write<P>>().cloned().ok_or(PersistentError::NotFound)
     }
 }
 
@@ -139,23 +149,23 @@ impl<P: Key> BeforeMiddleware for Write<P> where P::Value: Send {
 }
 
 impl<P: Key> AfterMiddleware for State<P> where P::Value: Send + Sync {
-    fn after(&self, _: &mut Request, res: &mut Response) -> IronResult<()> {
+    fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
         res.extensions.insert::<State<P>>(self.data.clone());
-        Ok(())
+        Ok(res)
     }
 }
 
 impl<P: Key> AfterMiddleware for Read<P> where P::Value: Send + Sync {
-    fn after(&self, _: &mut Request, res: &mut Response) -> IronResult<()> {
+    fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
         res.extensions.insert::<Read<P>>(self.data.clone());
-        Ok(())
+        Ok(res)
     }
 }
 
 impl<P: Key> AfterMiddleware for Write<P> where P::Value: Send {
-    fn after(&self, _: &mut Request, res: &mut Response) -> IronResult<()> {
+    fn after(&self, _: &mut Request, mut res: Response) -> IronResult<Response> {
         res.extensions.insert::<Write<P>>(self.data.clone());
-        Ok(())
+        Ok(res)
     }
 }
 


### PR DESCRIPTION
Hello @reem. I have refactored `persistent` so we can use it now in https://github.com/iron/body-parser/pull/43. 

I have to introduce the new [PluginError](https://github.com/iron/persistent/pull/35/files#diff-b4aea3e418ccdb71239b96952d9cddb6R18) enum to deal with NotFound case (because now we have Result in plugins). Is it OK?

