### PR TITLE
removing unstable feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
-#![feature(core)]
 
 //! A set of middleware for sharing data between requests in the Iron
 //! framework.


### PR DESCRIPTION
The core feature declaration is stopping `persistent` being build for rustc beta.