### PR TITLE
Derive Debug for PersistentError

### DIFF
--- a/examples/hitcounter.rs
+++ b/examples/hitcounter.rs
@@ -13,7 +13,7 @@ pub struct HitCounter;
 impl Key for HitCounter { type Value = usize; }
 
 fn serve_hits(req: &mut Request) -> IronResult<Response> {
-    let mutex = req.get::<Write<HitCounter>>().ok().unwrap();
+    let mutex = req.get::<Write<HitCounter>>().unwrap();
     let mut count = mutex.lock().unwrap();
 
     *count += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, RwLock, Mutex};
 use plugin::Plugin;
 
 /// The type that can be returned by `eval` to indicate error.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum PersistentError {
     /// The value was not found.
     NotFound


### PR DESCRIPTION
This allows `request.get::<persitent>().unwrap()`.