### PR TITLE
Implement std::error::Error for PersistentError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate plugin;
 use iron::{Request, Response, BeforeMiddleware, AfterMiddleware, IronResult};
 use iron::typemap::Key;
 use std::sync::{Arc, RwLock, Mutex};
+use std::{error,fmt};
 use plugin::Plugin;
 
 /// The type that can be returned by `eval` to indicate error.
@@ -17,6 +18,22 @@ use plugin::Plugin;
 pub enum PersistentError {
     /// The value was not found.
     NotFound
+}
+
+impl fmt::Display for PersistentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            PersistentError::NotFound => fmt::Display::fmt("value was not found", f)
+        }
+    }
+}
+
+impl error::Error for PersistentError {
+    fn description(&self) -> &str {
+        match *self {
+            PersistentError::NotFound => "value was not found"
+        }
+    }
 }
 
 /// Middleware for data that persists between requests with read and write capabilities.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,14 @@ pub enum PersistentError {
 
 impl fmt::Display for PersistentError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            PersistentError::NotFound => fmt::Display::fmt("value was not found", f)
-        }
+        fmt::Display::fmt(self, f)
     }
 }
 
 impl error::Error for PersistentError {
     fn description(&self) -> &str {
         match *self {
-            PersistentError::NotFound => "value was not found"
+            PersistentError::NotFound => "Value not found in extensions."
         }
     }
 }


### PR DESCRIPTION
This allows a `PersistentError` to be used when creating a new `IronError` like so:

```rust
fn handler(req: &mut Request) -> IronResult<Response> {
    let e : PersistentError = PersistentError::NotFound;
    Err(IronError::new(e, /* ... */))
}
```