### PR TITLE
(chore) Update to iron 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,5 @@ license = "MIT"
 keywords = ["iron", "web", "persistence", "sharing", "global"]
 
 [dependencies]
-iron = { version = "0.2", default-features = false }
+iron = "0.3"
 plugin = "0.2"
-


### PR DESCRIPTION
I wanted to upgrade `iron-test` to work with `iron` 0.3. This is the end of the dependency chain…