### PR TITLE
bump iron to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT"
 keywords = ["iron", "web", "persistence", "sharing", "global"]
 
 [dependencies]
-iron = "0.5"
+iron = "0.6"
 plugin = "0.2"


### PR DESCRIPTION
I'm getting some weird ICE with Iron 0.6 and it's not helping having `body-parser` and `persistent` pull in `iron 0.5` as well as my `iron 0.6`, so.. let's just upgrade everything to 0.6?