### PR TITLE
Bump up to iron 0.6 (>= 0.5, < 0.7)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "persistent"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
-version = "0.3.0"
+version = "0.6.0"
 description = "A set of middleware for sharing server-global data in Iron."
 repository = "https://github.com/iron/persistent"
 documentation = "http://ironframework.io/doc/persistent/index.html"
@@ -10,5 +10,5 @@ license = "MIT"
 keywords = ["iron", "web", "persistence", "sharing", "global"]
 
 [dependencies]
-iron = "0.5"
+iron = ">= 0.5, < 0.7"
 plugin = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "persistent"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
-version = "0.6.0"
+version = "0.4.0"
 description = "A set of middleware for sharing server-global data in Iron."
 repository = "https://github.com/iron/persistent"
 documentation = "http://ironframework.io/doc/persistent/index.html"


### PR DESCRIPTION
This is similar to https://github.com/iron/persistent/pull/64 except it also rewrites persistent's version.

I thought it is slightly impolite for @FauxFaux, but use this if they don't respond after folks complain the issue.